### PR TITLE
fix: check if stdout is a number

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -149,8 +149,7 @@ export class Foreman {
 	public has(id: ProcessIdentifier): boolean {
 		try {
 			const { stdout } = shellSync(`pm2 id ${id} | awk '{ print $2 }'`);
-
-			return !!stdout;
+			return !!stdout && !isNaN(Number(stdout));
 		} catch (error) {
 			return false;
 		}


### PR DESCRIPTION
When the pm2 daemon is not running it is spawned which results in:
```shell
$ pm2 id ark-relay | awk '{ print $2 }'
Spawning
PM2

```
This breaks `has` since it simply checks wether `stdout` is truthy or not.

What lead me to this bug is the following Core error:
```shell
TypeError: Cannot destructure property `pm2_env` of 'undefined' or 'null'.
    at LogCommand.run (~/git/ark-core/packages/core/dist/shared/log.js:17:62)
```
which can be reproduced when running a command for a process which isn't running
e.g. `ark relay:log` while the pm2 daemon itself isn't running.